### PR TITLE
fix for rollover of micros() during move.

### DIFF
--- a/TMC26XStepper.cpp
+++ b/TMC26XStepper.cpp
@@ -247,8 +247,8 @@ char TMC26XStepper::move(void) {
   // decrement the number of steps, moving one step each time:
   if(this->steps_left>0) {
       unsigned long time = micros();  
-	  // move only if the appropriate delay has passed:
- 	 if (time >= this->next_step_time) {
+	  // move only if the appropriate delay has passed: (Update allows millis() to roll over)
+	  if(abs(time - this->last_step_time) > this->step_delay) {
    	 	// increment or decrement the step number,
    	 	// depending on direction:
    	 	if (this->direction == 1) {


### PR DESCRIPTION
This will fix a problem where calling step() while micros() rolled over to 0 would cause the motor to not take anymore steps.