### PR TITLE
fixed to build and run with ControlP5 2.2.5

### DIFF
--- a/examples/TMC26XMotorTester/processing/TMC26XMotorTest/Arduino.pde
+++ b/examples/TMC26XMotorTester/processing/TMC26XMotorTest/Arduino.pde
@@ -45,7 +45,7 @@ void setupSerialConfig() {
   //add the list of serial interfaces - it get's populated later
   serialButtons = controlP5.addRadioButton("serialport", 200, 100+TMCLogo.height*2+50);
   serialConfigElements.add(serialButtons);
-  serialButtons.captionLabel().set("Select Serial Port");
+  serialButtons.getCaptionLabel().set("Select Serial Port");
   serialButtons.showBar();
   serialButtons.moveTo(defaultTab);
   //ad the ok button

--- a/examples/TMC26XMotorTester/processing/TMC26XMotorTest/ChopperConfiguration.pde
+++ b/examples/TMC26XMotorTester/processing/TMC26XMotorTest/ChopperConfiguration.pde
@@ -168,7 +168,7 @@ void setHystDecrement(int value) {
 }
 
 void motorcurrent(float value) {
-  if (activeTab!=null && "default".equals(activeTab.name())) {
+  if (activeTab!=null && "default".equals(activeTab.getName())) {
     currentSlider.setValue(value);
   }
 }

--- a/examples/TMC26XMotorTester/processing/TMC26XMotorTest/RunConfiguration.pde
+++ b/examples/TMC26XMotorTester/processing/TMC26XMotorTest/RunConfiguration.pde
@@ -131,7 +131,7 @@ void setupRunConfig() {
 
   coolStepIncrementButtons = controlP5.addRadioButton("coolStepIncrement", 600, 40);
   controlElements.add(coolStepIncrementButtons);
-  coolStepIncrementButtons.captionLabel().set("Cool Step  Increment");
+  coolStepIncrementButtons.getCaptionLabel().set("Cool Step  Increment");
   coolStepIncrementButtons.addItem("i_1", 0);
   coolStepIncrementButtons.addItem("i_2", 1);
   coolStepIncrementButtons.addItem("i_4", 2);
@@ -145,7 +145,7 @@ void setupRunConfig() {
 
   coolStepDecrementButtons = controlP5.addRadioButton("coolStepDecrement", 600, 110);
   controlElements.add(coolStepDecrementButtons);
-  coolStepDecrementButtons.captionLabel().set("Cool Step Decrement");
+  coolStepDecrementButtons.getCaptionLabel().set("Cool Step Decrement");
   coolStepDecrementButtons.addItem("d_32", 0);
   coolStepDecrementButtons.addItem("d_8", 1);
   coolStepDecrementButtons.addItem("d_2", 2);
@@ -222,13 +222,13 @@ void stallguardthreshold(int value) {
     println("stall guard threshold: "+value);
     sendCommand("t"+value);
   }
-  if (value==sgtSlider.max()) {
+  if (value==sgtSlider.getMax()) {
     sgtPlus.lock();
   } 
   else {
     sgtPlus.unlock();
   }
-  if (value==sgtSlider.min()) {
+  if (value==sgtSlider.getMin()) {
     sgtMinus.lock();
   } 
   else {
@@ -237,11 +237,11 @@ void stallguardthreshold(int value) {
 }
 
 void sgtplus(int value) {
-  sgtSlider.setValue(sgtSlider.value()+1);
+  sgtSlider.setValue(sgtSlider.getValue()+1);
 }
 
 void sgtminus(int value) {
-  sgtSlider.setValue(sgtSlider.value()-1);
+  sgtSlider.setValue(sgtSlider.getValue()-1);
 }
 
 void sgfilter(int value) {
@@ -256,7 +256,7 @@ void current(float value) {
     int realValue=(int)(value*1000.0);
     println("current: "+((float)realValue/1000.0)+" = "+realValue);
     sendCommand("c"+realValue);
-    if (activeTab!=null && "run".equals(activeTab.name())) {
+    if (activeTab!=null && "run".equals(activeTab.getName())) {
       motorCurrentBox.setValue(value);
     }
   }

--- a/examples/TMC26XMotorTester/processing/TMC26XMotorTest/TMC26XMotorTest.pde
+++ b/examples/TMC26XMotorTester/processing/TMC26XMotorTest/TMC26XMotorTest.pde
@@ -134,23 +134,23 @@ void draw() {
 
 void controlEvent(ControlEvent theEvent) {
   if (theEvent.isGroup() && !settingStatus) {
-    if ("microstepping".equals(theEvent.group().name())) { 
-      microstepping((int)theEvent.group().value());
+    if ("microstepping".equals(theEvent.group().getName())) { 
+      microstepping((int)theEvent.group().getValue());
     } else 
-    if ("direction".equals(theEvent.group().name())) {
-      setDirection((int)theEvent.group().value());
-    } else if ("decrement".equals(theEvent.group().name())) {
-      setHysteresisDecrement((int)theEvent.group().value());
-    } else if ("coolStepIncrement".equals(theEvent.group().name())) {
-      setCoolStepIncrement((int)theEvent.group().value());
-    } else if ("coolStepDecrement".equals(theEvent.group().name())) {
-      setCoolStepDecrement((int)theEvent.group().value());
-    } else if ("coolStepMin".equals(theEvent.group().name())) {
-      setCoolStepMin((int)theEvent.group().value());
+    if ("direction".equals(theEvent.group().getName())) {
+      setDirection((int)theEvent.group().getValue());
+    } else if ("decrement".equals(theEvent.group().getName())) {
+      setHysteresisDecrement((int)theEvent.group().getValue());
+    } else if ("coolStepIncrement".equals(theEvent.group().getName())) {
+      setCoolStepIncrement((int)theEvent.group().getValue());
+    } else if ("coolStepDecrement".equals(theEvent.group().getName())) {
+      setCoolStepDecrement((int)theEvent.group().getValue());
+    } else if ("coolStepMin".equals(theEvent.group().getName())) {
+      setCoolStepMin((int)theEvent.group().getValue());
     }
   } 
   else if (theEvent.isTab()) {
     activeTab = theEvent.tab();
-    println("Tab: "+activeTab.name());
+    println("Tab: "+activeTab.getName());
   } 
 }


### PR DESCRIPTION
Basically replacing some method calls with their "getXYZ()" replacements.
I can now run the TMC26XMotorTester on the Arduino and control it using TMC26XStepper in Processing 2.2.1 with ControlP 2.2.5.