### PR TITLE
Move Arduino.h #include directive to TMC26XStepper.h

### DIFF
--- a/TMC26XStepper.cpp
+++ b/TMC26XStepper.cpp
@@ -25,11 +25,6 @@
  
  */
 
-#if defined(ARDUINO) && ARDUINO >= 100
-	#include <Arduino.h>
-#else
-	#include <WProgram.h>
-#endif
 #include <SPI.h>
 #include "TMC26XStepper.h"
 

--- a/TMC26XStepper.h
+++ b/TMC26XStepper.h
@@ -30,6 +30,12 @@
 #ifndef TMC26XStepper_h
 #define TMC26XStepper_h
 
+#if defined(ARDUINO) && ARDUINO >= 100
+	#include <Arduino.h>
+#else
+	#include <WProgram.h>
+#endif
+
 //! return value for TMC26XStepper.getOverTemperature() if there is a overtemperature situation in the TMC chip
 /*!
  * This warning indicates that the TCM chip is too warm. 


### PR DESCRIPTION
TMC26XStepper.h uses the non-standard `boolean` type which is defined in the Arduino core library. The use of this type in TMC26XStepper.h relied on Arduino.h having been included externally before TMC26XStepper.h. While this would typically be done automatically by the Arduino sketch preprocessor if TMC26XStepper.h was included from an .ino file, that behavior is not guaranteed and the Arduino.h `#include` directive is not automatically to any other type of source file. Thus the best solution is to simply include the external dependency in the file that requires it.

Fixes https://github.com/trinamic/TMC26XStepper/issues/9

Note that an alternative solution would be to use the standard `bool` type rather than the non-standard `boolean`. If you prefer that I would be happy to submit a pull request.